### PR TITLE
Fixed "setDbId()" bug on AudioMetaBuilder and FileMetaBuilder class

### DIFF
--- a/src/main/java/com/team04/musiccloud/audio/AudioMetaBuilder.java
+++ b/src/main/java/com/team04/musiccloud/audio/AudioMetaBuilder.java
@@ -43,6 +43,6 @@ public class AudioMetaBuilder {
     }
     
     public AudioMeta build() {
-        return new AudioMeta(title, author, album, releaseDate);
+        return new AudioMeta(dbId, title, author, album, releaseDate);
     }
 }

--- a/src/main/java/com/team04/musiccloud/audio/FileMetaBuilder.java
+++ b/src/main/java/com/team04/musiccloud/audio/FileMetaBuilder.java
@@ -41,6 +41,6 @@ public class FileMetaBuilder {
     }
     
     public FileMeta build() {
-        return new FileMeta(directory, name, extension, user);
+        return new FileMeta(dbId, directory, name, extension, user);
     }
 }


### PR DESCRIPTION
- Fixed a problem of setDbId() always returning null