### PR TITLE
Reassigned package name on some classes

### DIFF
--- a/src/main/java/com/team04/musiccloud/MusiccloudApplication.java
+++ b/src/main/java/com/team04/musiccloud/MusiccloudApplication.java
@@ -1,10 +1,10 @@
 package com.team04.musiccloud;
 
-import com.team04.musiccloud.audio.ExtractorException;
-import com.team04.musiccloud.audio.InvalidFileFormat;
-import com.team04.musiccloud.audio.Tester;
+import com.team04.musiccloud.audio.extractor.ExtractorException;
+import com.team04.musiccloud.audio.extractor.InvalidFileFormat;
 import com.team04.musiccloud.caching.AudioCaching;
 import com.team04.musiccloud.controller.SampleStreamingController;
+import com.team04.musiccloud.tester.Tester;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 

--- a/src/main/java/com/team04/musiccloud/audio/extractor/AudioExtractor.java
+++ b/src/main/java/com/team04/musiccloud/audio/extractor/AudioExtractor.java
@@ -1,7 +1,12 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.audio.extractor;
 
+import com.team04.musiccloud.audio.Audio;
+import com.team04.musiccloud.audio.AudioMeta;
+import com.team04.musiccloud.audio.AudioMetaBuilder;
+import com.team04.musiccloud.audio.FileMeta;
 import com.team04.musiccloud.utilities.DateTimeUtilities;
 import com.team04.musiccloud.utilities.FileSystemUtilities;
+import com.team04.musiccloud.utilities.StaticPaths;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;

--- a/src/main/java/com/team04/musiccloud/audio/extractor/ExtractorException.java
+++ b/src/main/java/com/team04/musiccloud/audio/extractor/ExtractorException.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.audio.extractor;
 
 public class ExtractorException extends Exception {
     public ExtractorException() {

--- a/src/main/java/com/team04/musiccloud/audio/extractor/ExtractorFactory.java
+++ b/src/main/java/com/team04/musiccloud/audio/extractor/ExtractorFactory.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.audio.extractor;
 
 import com.team04.musiccloud.utilities.FileSystemUtilities;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/team04/musiccloud/audio/extractor/InvalidFileFormat.java
+++ b/src/main/java/com/team04/musiccloud/audio/extractor/InvalidFileFormat.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.audio.extractor;
 
 public class InvalidFileFormat extends Exception {
     public InvalidFileFormat() {

--- a/src/main/java/com/team04/musiccloud/audio/extractor/Mp3Extractor.java
+++ b/src/main/java/com/team04/musiccloud/audio/extractor/Mp3Extractor.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.audio.extractor;
 
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;

--- a/src/main/java/com/team04/musiccloud/caching/manager/CacheManager.java
+++ b/src/main/java/com/team04/musiccloud/caching/manager/CacheManager.java
@@ -1,4 +1,7 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.caching.manager;
+
+import com.team04.musiccloud.audio.FileMeta;
+import com.team04.musiccloud.utilities.StaticPaths;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/com/team04/musiccloud/caching/manager/UserTempAlreadyExists.java
+++ b/src/main/java/com/team04/musiccloud/caching/manager/UserTempAlreadyExists.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.caching.manager;
 
 public class UserTempAlreadyExists extends RuntimeException {
     public UserTempAlreadyExists() {

--- a/src/main/java/com/team04/musiccloud/controller/SampleStreamingController.java
+++ b/src/main/java/com/team04/musiccloud/controller/SampleStreamingController.java
@@ -1,9 +1,9 @@
 package com.team04.musiccloud.controller;
 
 import com.team04.musiccloud.audio.Audio;
-import com.team04.musiccloud.audio.AudioExtractor;
-import com.team04.musiccloud.audio.ExtractorException;
-import com.team04.musiccloud.audio.Mp3Extractor;
+import com.team04.musiccloud.audio.extractor.AudioExtractor;
+import com.team04.musiccloud.audio.extractor.ExtractorException;
+import com.team04.musiccloud.audio.extractor.Mp3Extractor;
 import com.team04.musiccloud.auth.AccountService;
 import com.team04.musiccloud.stream.Streaming;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/team04/musiccloud/network/UserNetStatus.java
+++ b/src/main/java/com/team04/musiccloud/network/UserNetStatus.java
@@ -1,6 +1,6 @@
 package com.team04.musiccloud.network;
 
-import com.team04.musiccloud.data_structure.UpdateDeque;
+import com.team04.musiccloud.utilities.UpdateDeque;
 
 import java.util.Objects;
 import java.util.Queue;

--- a/src/main/java/com/team04/musiccloud/tester/Tester.java
+++ b/src/main/java/com/team04/musiccloud/tester/Tester.java
@@ -1,6 +1,15 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.tester;
 
+import com.team04.musiccloud.audio.Audio;
+import com.team04.musiccloud.audio.AudioMeta;
+import com.team04.musiccloud.audio.FileMeta;
+import com.team04.musiccloud.audio.extractor.AudioExtractor;
+import com.team04.musiccloud.audio.extractor.ExtractorException;
+import com.team04.musiccloud.audio.extractor.ExtractorFactory;
+import com.team04.musiccloud.audio.extractor.InvalidFileFormat;
+import com.team04.musiccloud.caching.manager.CacheManager;
 import com.team04.musiccloud.utilities.FileSystemUtilities;
+import com.team04.musiccloud.utilities.StaticPaths;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/team04/musiccloud/utilities/FixedDeque.java
+++ b/src/main/java/com/team04/musiccloud/utilities/FixedDeque.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.data_structure;
+package com.team04.musiccloud.utilities;
 
 import java.util.ArrayDeque;
 import java.util.Objects;

--- a/src/main/java/com/team04/musiccloud/utilities/OverSizeLimitException.java
+++ b/src/main/java/com/team04/musiccloud/utilities/OverSizeLimitException.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.data_structure;
+package com.team04.musiccloud.utilities;
 
 public class OverSizeLimitException extends RuntimeException {
     public OverSizeLimitException() {

--- a/src/main/java/com/team04/musiccloud/utilities/StaticPaths.java
+++ b/src/main/java/com/team04/musiccloud/utilities/StaticPaths.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.audio;
+package com.team04.musiccloud.utilities;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/main/java/com/team04/musiccloud/utilities/UpdateDeque.java
+++ b/src/main/java/com/team04/musiccloud/utilities/UpdateDeque.java
@@ -1,4 +1,4 @@
-package com.team04.musiccloud.data_structure;
+package com.team04.musiccloud.utilities;
 
 public class UpdateDeque<T> extends FixedDeque<T> {
     public UpdateDeque(int capacity) {

--- a/src/test/java/com/team04/musiccloud/stream/StreamingTest.java
+++ b/src/test/java/com/team04/musiccloud/stream/StreamingTest.java
@@ -1,18 +1,19 @@
 package com.team04.musiccloud.stream;
 
-import static org.junit.Assert.assertEquals;
-
 import com.team04.musiccloud.audio.Audio;
-import com.team04.musiccloud.audio.AudioExtractor;
-import com.team04.musiccloud.audio.Mp3Extractor;
-import java.io.FileInputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import com.team04.musiccloud.audio.extractor.AudioExtractor;
+import com.team04.musiccloud.audio.extractor.Mp3Extractor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.FileInputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
 
 public class StreamingTest {
 


### PR DESCRIPTION
- Added "audio‚extractor", "caching‚manager", "tester"
- Moved "Extractor" related class to "extractor" package
- Moved "CacheManager" related classes to "caching/manager" package
- Moved "Tester" class to "tester" package
- Moved "StaticPaths" class to "utilities" package
- Moved classes from "data_structure" package to "utilities" package