### PR TITLE
Transcode 가중치 계산 방식을 개선하였습니다.

### DIFF
--- a/src/main/java/com/team04/musiccloud/stream/transcode/Transcode.java
+++ b/src/main/java/com/team04/musiccloud/stream/transcode/Transcode.java
@@ -33,8 +33,7 @@ public class Transcode {
    */
   private double preProcessWeight(double weight) {
     //@TODO: weight에 대한 전처리를 해주도록 합니다. 이 부분은 담당자와 협의가 요구됩니다.
-    // calculator를 활용해주시길 바랍니다.
-    return weight;
+    return calculator.value(weight/10000);
   }
 
   public void setWeight(double weight) {

--- a/src/test/java/com/team04/musiccloud/stream/transcode/TranscodeTest.java
+++ b/src/test/java/com/team04/musiccloud/stream/transcode/TranscodeTest.java
@@ -42,15 +42,15 @@ public class TranscodeTest {
   public void setWeightTest() {
     double weight;
 
-    transcode.setWeight(81);
+    transcode.setWeight(14000); // 14s
     weight = transcode.getWeight();
     assertEquals(DefaultAttributes.MP3_128KBS_STEREO_44KHZ, transcode.getAudioSetting(weight));
 
-    transcode.setWeight(66);
+    transcode.setWeight(7000); // 7s
     weight = transcode.getWeight();
     assertEquals(DefaultAttributes.MP3_192KBS_STEREO_44KHZ, transcode.getAudioSetting(weight));
 
-    transcode.setWeight(23);
+    transcode.setWeight(1000); // 1s
     weight = transcode.getWeight();
     assertEquals(DefaultAttributes.MP3_320KBS_STEREO_44KHZ, transcode.getAudioSetting(weight));
   }


### PR DESCRIPTION
기존의 second 기반의 가중치 계산 방식을 milli second에 맞게 변경을 하였으며, 그 값이 너무 튀는 경우의 한계치를 주기 위해서 Sigmoid 함수를 사용했습니다.