### PR TITLE
AudioMeta에 durationMs 필드 추가에 따른 AudioMetaConverter 수정

### DIFF
--- a/src/main/java/com/team04/musiccloud/db/converter/AudioMetaConverter.java
+++ b/src/main/java/com/team04/musiccloud/db/converter/AudioMetaConverter.java
@@ -14,7 +14,8 @@ public class AudioMetaConverter {
     Document document = new Document("title", audioMeta.getTitle())
         .append("author", audioMeta.getAuthor())
         .append("album", audioMeta.getAlbum())
-        .append("releaseDate", audioMeta.getReleaseDate().toString());
+        .append("releaseDate", audioMeta.getReleaseDate().toString())
+        .append("durationMs", audioMeta.getDurationMs());
     if (audioMeta.getDbId() == null) {
       document.append("_id", new ObjectId());
     } else {
@@ -39,6 +40,7 @@ public class AudioMetaConverter {
         .setTitle((String) document.get("title"))
         .setAuthor((String) document.get("author"))
         .setAlbum((String) document.get("album"))
-        .setReleaseDate(dateTime).build();
+        .setReleaseDate(dateTime)
+        .setDurationMs((int) document.get("durationMs")).build();
   }
 }


### PR DESCRIPTION
AudioMetaConverter.java
1. toDocument 함수에 .append("durationMs", audioMeta.getDurationMs()) 추가
2. toAudioMeta 함수에 setDuration((int) document.get("durationMs")).build() 추가