### PR TITLE
음악 진행 바를 클릭하였을때 반응하지 않던 버그 수정

### DIFF
--- a/src/main/java/com/team04/musiccloud/controller/PlayerController.java
+++ b/src/main/java/com/team04/musiccloud/controller/PlayerController.java
@@ -61,10 +61,10 @@ public class PlayerController {
    */
   // @TODO (2019년 5월 19일 추가) Player.jsp에서 시간 관련해서 문제가 있는 것 같다.
   private String audioTagGenerator(String audioLocation, String fileExtension) {
-    return "<audio id=\"bgAudio\" controls style=\"display:none;\"><source src=\""
+    return "<audio id=\"bgAudio\" controls style=\"display:none;\" preload=\"metadata\"><source src=\""
         + audioLocation
         + "\" type=\"audio/" + MusicFileUtilities.getMimeType(fileExtension)
-        + "\" id=\"nowPlaying\"></audio>";
+        + "\" id=\"nowPlaying\" type=\"audio/mp3\"></audio>";
   }
 
   /**

--- a/src/main/java/com/team04/musiccloud/controller/SenderController.java
+++ b/src/main/java/com/team04/musiccloud/controller/SenderController.java
@@ -63,6 +63,7 @@ public class SenderController {
     if (mimeType != null) {
       header.setContentType(new MediaType("audio", mimeType));
       header.setContentLength(audio.getBytes().length);
+      header.add("Accept-Ranges","bytes");
     }
 
     return new HttpEntity<>(audio.getBytes(), header);

--- a/src/main/resources/static/js/myPlayer.js
+++ b/src/main/resources/static/js/myPlayer.js
@@ -75,29 +75,33 @@ function togglePlayPauseButton(my_audio){
 }
 
 function secondToText(duration){
-  var minuteText = parseInt(duration / 60);
-  var second = parseInt(duration % 60);
-  var secondText = (second>=10)? second : "0"+second;
-  var music_playtime = minuteText + ":" + secondText;
+  if(isNaN(duration)){
+    return "Loading...";
+  }
+  else{
+    var minuteText = parseInt(duration / 60);
+    var second = parseInt(duration % 60);
+    var secondText = (second>=10)? second : "0"+second;
+    var music_playtime = minuteText + ":" + secondText;
 
-  return music_playtime;
+    return music_playtime;
+  }
 }
 
 function playtimeUpdate(my_audio){
 
-  // Set Music Total Time
-  var musicTotalTime = secondToText(my_audio.duration);
-  document.getElementById("music_totaltime").innerHTML = musicTotalTime;
-
   var music_progress_percent;
 
+  // Set Music Total Time
   // Set Music Play Time
   if (my_audio.paused == false) {
     showPlayTime = setInterval(function () {
 
+      var musicTotalTime = secondToText(my_audio.duration);
       var musicPlayTime = secondToText(my_audio.currentTime);
 
       document.getElementById("music_playtime").innerHTML = musicPlayTime;
+      document.getElementById("music_totaltime").innerHTML = musicTotalTime;
 
       if(isSongProgressSliderUsable){
         progress_percent = my_audio.currentTime / my_audio.duration * 100;


### PR DESCRIPTION
## - 파일별 변경사항 설명 -
-------------------------------------------------------------------------------------------------------
**PlayerController.java**
+ Audio Tag의 preload 속성을 metadata를 우선으로 다운로드 받게 변경 (기존 값 : none)
+ Audio Tag의 음악 파일 속성 값을 .mp3 파일로 수정

 **SenderController.java**
+ Response Header에 Accept-Ranges 필드를 추가하여 파일의 중간부분의 요청을 처리할 수 있게 함

**myplayer.js**
+ 음악 Progress Bar에서 기존의 NaN으로 표시되던 음악 총 길이를 Loading...으로 표시하도록 수정
------------------------------------------------------------------------------------------------------