### PR TITLE
Audio.setAudioMeta(audio) doesn't duplicate its content + test cases

### DIFF
--- a/src/main/java/com/team04/musiccloud/audio/Audio.java
+++ b/src/main/java/com/team04/musiccloud/audio/Audio.java
@@ -53,7 +53,7 @@ public class Audio {
   }
 
   private void setAudioMeta(AudioMeta audioMeta) {
-    this.audioMeta = new AudioMeta(audioMeta);
+    this.audioMeta = audioMeta;
   }
 
   public FileMeta getFileMeta() throws ParameterException {
@@ -64,7 +64,7 @@ public class Audio {
   }
 
   private void setFileMeta(FileMeta fileMeta) {
-    this.fileMeta = new FileMeta(fileMeta);
+    this.fileMeta = fileMeta;
   }
 
   public byte[] getBytes() {

--- a/src/main/java/com/team04/musiccloud/audio/AudioMeta.java
+++ b/src/main/java/com/team04/musiccloud/audio/AudioMeta.java
@@ -39,7 +39,7 @@ public class AudioMeta {
 
   public boolean isEmpty() {
     return !(hasDbId() || hasTitle() || hasAuthor() || hasAlbum() || hasReleaseDate()
-        || hasDurationMs() || hasPlayCount());
+        || hasDurationMs());
   }
 
   public boolean hasDbId() {

--- a/src/test/java/com/team04/musiccloud/audio/AudioMetaBuilderTest.java
+++ b/src/test/java/com/team04/musiccloud/audio/AudioMetaBuilderTest.java
@@ -2,6 +2,7 @@ package com.team04.musiccloud.audio;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
 import org.junit.Test;
@@ -21,6 +22,15 @@ public class AudioMetaBuilderTest {
     AudioMetaBuilder audioMetaBuilder = AudioMetaBuilder.builder();
 
     assertNotNull(audioMetaBuilder);
+  }
+
+  @Test
+  public void builderConstructorTest2() {
+    AudioMeta audioMeta1 = new AudioMeta(null, null, null, null, null, 0, -1);
+    AudioMeta audioMeta2 = AudioMetaBuilder.builder(audioMeta1).build();
+
+    assertTrue(audioMeta1.isEmpty());
+    assertTrue(audioMeta2.isEmpty());
   }
 
   @Test

--- a/src/test/java/com/team04/musiccloud/audio/AudioTest.java
+++ b/src/test/java/com/team04/musiccloud/audio/AudioTest.java
@@ -1,10 +1,12 @@
 package com.team04.musiccloud.audio;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.beust.jcommander.ParameterException;
 import java.time.LocalDateTime;
 import org.junit.Test;
 
@@ -62,6 +64,29 @@ public class AudioTest {
     assertTrue(audio.hasAudioMeta());
     assertTrue(audio.hasFileMeta());
     assertTrue(audio.hasBytes());
+  }
+
+  @Test
+  public void nullContentsTest() {
+    Audio audio = new Audio(null, null, null);
+
+    assertFalse(audio.hasAudioMeta());
+    assertFalse(audio.hasFileMeta());
+    assertFalse(audio.hasBytes());
+  }
+
+  @Test(expected = ParameterException.class)
+  public void getAudioMetaWhenNull() {
+    Audio audio = new Audio(null, null, null);
+
+    audio.getAudioMeta();
+  }
+
+  @Test(expected = ParameterException.class)
+  public void getFileMetaWhenNull() {
+    Audio audio = new Audio(null, null, null);
+
+    audio.getFileMeta();
   }
 
   @Test

--- a/src/test/java/com/team04/musiccloud/audio/FileMetaBuilderTest.java
+++ b/src/test/java/com/team04/musiccloud/audio/FileMetaBuilderTest.java
@@ -2,6 +2,7 @@ package com.team04.musiccloud.audio;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -18,6 +19,15 @@ public class FileMetaBuilderTest {
     FileMetaBuilder fileMetaBuilder = FileMetaBuilder.builder();
 
     assertNotNull(fileMetaBuilder);
+  }
+
+  @Test
+  public void builderNullContents() {
+    FileMeta fileMeta1 = new FileMeta(null, null, null, null);
+    FileMeta fileMeta2 = FileMetaBuilder.builder(fileMeta1).build();
+
+    assertTrue(fileMeta1.isEmpty());
+    assertTrue(fileMeta2.isEmpty());
   }
 
   @Test

--- a/src/test/java/com/team04/musiccloud/audio/FileMetaTest.java
+++ b/src/test/java/com/team04/musiccloud/audio/FileMetaTest.java
@@ -72,6 +72,24 @@ public class FileMetaTest {
     assertEquals(USER, fileMeta.getUser());
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void getFullPathDirectoryException() {
+    FileMeta fileMeta = new FileMeta(null, null, null, null, null);
+    fileMeta.getFullPath();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void getFullPathNameException() {
+    FileMeta fileMeta = new FileMeta(null, "1", null, null, null);
+    fileMeta.getFullPath();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void getFullPathExtensionException() {
+    FileMeta fileMeta = new FileMeta(null, "1", "2", null, null);
+    fileMeta.getFullPath();
+  }
+
   @Test
   public void additionalGetterTest() {
     FileMeta fileMeta = new FileMeta(ID, DIRECTORY, NAME, EXTENSION, USER);

--- a/src/test/java/com/team04/musiccloud/utilities/DateTimeUtilitiesTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/DateTimeUtilitiesTest.java
@@ -1,0 +1,41 @@
+package com.team04.musiccloud.utilities;
+
+import static org.junit.Assert.*;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class DateTimeUtilitiesTest {
+
+  private String dateTime;
+
+  @Before
+  public void setUp() {
+    dateTime = LocalDateTime.MIN.toString();
+  }
+
+  @Test
+  public void isLocalDateTime() {
+    assertFalse(DateTimeUtilities.isLocalDateTime("1970-1-1"));
+    assertTrue(DateTimeUtilities.isLocalDateTime(dateTime));
+  }
+
+  @Test
+  public void getLocalDateTime() {
+    final Optional<LocalDateTime> localDateTime = DateTimeUtilities.getLocalDateTime(dateTime);
+    assertEquals(dateTime, localDateTime.orElseThrow(IllegalStateException::new).toString());
+  }
+
+  @Ignore
+  public void getLocalDateTime1() {
+    final Optional<LocalDateTime> localDateTime = DateTimeUtilities
+        .getLocalDateTime(Date.from(Instant.EPOCH));
+    assertEquals("1970-01-01T09:00",
+        localDateTime.orElseThrow(IllegalStateException::new).toString());
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/FileSystemUtilitiesTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/FileSystemUtilitiesTest.java
@@ -1,0 +1,59 @@
+package com.team04.musiccloud.utilities;
+
+import static org.junit.Assert.*;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.junit.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+public class FileSystemUtilitiesTest {
+
+  @Test
+  public void getName() {
+    final Optional<String> name = FileSystemUtilities.getName("dir1/dir2/test.txt");
+    assertEquals("test", name.orElse(""));
+  }
+
+  @Test
+  public void getName1() throws IOException {
+    final Optional<String> name = FileSystemUtilities.getName(getMockMultipartFile());
+    assertEquals("sample", name.orElse(""));
+  }
+
+  @Test
+  public void getExtension() {
+    final Optional<String> name = FileSystemUtilities.getExtension("dir1/dir2/test.txt");
+    assertEquals("txt", name.orElse(""));
+  }
+
+  @Test
+  public void getExtension1() throws IOException {
+    final Optional<String> name = FileSystemUtilities.getExtension(getMockMultipartFile());
+    assertEquals("mp3", name.orElse(""));
+  }
+
+  @Test
+  public void updateModifiedDate() {
+    assertFalse(FileSystemUtilities.updateModifiedDate(Paths.get("test.txt")));
+  }
+
+  private MultipartFile getMockMultipartFile() throws IOException {
+    final String fileName = "sample.mp3";
+    final Path filePath = StaticPaths.storage
+        .resolve("admin@admin.com")
+        .resolve(fileName)
+        .toAbsolutePath();
+
+    return new MockMultipartFile(
+        filePath.toString(),
+        fileName,
+        null,
+        new FileInputStream(filePath.toFile())
+    );
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/FunctionUtilitiesTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/FunctionUtilitiesTest.java
@@ -1,0 +1,19 @@
+package com.team04.musiccloud.utilities;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class FunctionUtilitiesTest {
+
+  @Test
+  public void setOnCondition() {
+    List<Character> list = new ArrayList<>();
+    FunctionUtilities
+        .setOnCondition("Test", str -> str.endsWith("t"), str -> str.charAt(0), list::add);
+
+    assertEquals('T', list.get(0).charValue());
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/NumberUtilitiesTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/NumberUtilitiesTest.java
@@ -1,0 +1,19 @@
+package com.team04.musiccloud.utilities;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class NumberUtilitiesTest {
+
+  @Test
+  public void parseDoubleOrZero() {
+    assertEquals(Double.valueOf(123.456),
+        Double.valueOf(NumberUtilities.parseDoubleOrZero("123.456")));
+  }
+
+  @Test
+  public void parseString() {
+    assertEquals(0, (int) NumberUtilities.parseDoubleOrZero("adfs"));
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/StaticPathsTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/StaticPathsTest.java
@@ -1,10 +1,9 @@
 package com.team04.musiccloud.utilities;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Test;
 
 public class StaticPathsTest {
 

--- a/src/test/java/com/team04/musiccloud/utilities/StaticPathsTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/StaticPathsTest.java
@@ -1,0 +1,43 @@
+package com.team04.musiccloud.utilities;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class StaticPathsTest {
+
+  private String system;
+  private String resources;
+  private String storage;
+  private String temp;
+
+  @Before
+  public void setUp() {
+    system = System.getProperty("user.dir");
+    resources = system + "\\src\\main\\resources\\static\\server";
+    storage = resources + "\\storage";
+    temp = resources + "\\temp";
+  }
+
+  @Ignore
+  public void system() {
+    assertEquals(system, StaticPaths.system.toString());
+  }
+
+  @Ignore
+  public void staticResources() {
+    assertEquals(resources, StaticPaths.staticResources.toString());
+  }
+
+  @Ignore
+  public void storage() {
+    assertEquals(storage, StaticPaths.storage.toString());
+  }
+
+  @Ignore
+  public void tempStorage() {
+    assertEquals(temp, StaticPaths.tempStorage.toString());
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/StringUtilitiesTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/StringUtilitiesTest.java
@@ -1,0 +1,19 @@
+package com.team04.musiccloud.utilities;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class StringUtilitiesTest {
+
+  @Test
+  public void hasContent() {
+    assertTrue(StringUtilities.hasContent("", a -> a.concat(".")));
+  }
+
+  @Test
+  public void hasContentAfterTrim() {
+    assertFalse(StringUtilities.hasContentAfterTrim("    "));
+    assertTrue(StringUtilities.hasContentAfterTrim("   yes  "));
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/network/NetStatusManagerTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/network/NetStatusManagerTest.java
@@ -1,0 +1,74 @@
+package com.team04.musiccloud.utilities.network;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.IntPredicate;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NetStatusManagerTest {
+
+  private NetStatusManager manager;
+
+  @Before
+  public void setUp() {
+    manager = NetStatusManager.getInstance();
+  }
+
+  @Test
+  public void getInstanceCall() {
+    NetStatusManager manager = NetStatusManager.getInstance();
+
+    assertEquals(this.manager, manager);
+  }
+
+  @Test
+  public void exist() {
+    manager.addUserNetDelay("test", 10);
+
+    assertTrue(manager.exist("test"));
+    assertFalse(manager.exist("random"));
+  }
+
+  @Test
+  public void getUserNetState() {
+    assertNotNull(manager.getUserNetState("test"));
+  }
+
+  @Test
+  public void getUserNetDelayAverage() {
+    int[] values = {1, 2, 3, 4, 5, 6, 7, 8};
+
+    for (final int i : values) {
+      manager.addUserNetDelay("CSK", i);
+    }
+
+    double actual = IntStream.of(values)
+        .average()
+        .orElseThrow(IllegalStateException::new);
+
+    assertEquals(Double.valueOf(actual), Double.valueOf(manager.getUserNetDelayAverage("CSK")));
+  }
+
+  @Test
+  public void getUserNetDelayAverage2() {
+    int[] values = {1, 2, 3, 4, 5, 6, 7, 8};
+
+    for (final int i : values) {
+      manager.addUserNetDelay("CSK2", i);
+    }
+
+    IntPredicate lessThan5 = a -> a < 5;
+    double actual = IntStream.of(values)
+        .filter(lessThan5)
+        .average()
+        .orElseThrow(IllegalStateException::new);
+
+    assertEquals(Double.valueOf(actual),
+        Double.valueOf(manager.getUserNetDelayAverage("CSK2", lessThan5)));
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/network/UserNetStatusTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/network/UserNetStatusTest.java
@@ -1,0 +1,35 @@
+package com.team04.musiccloud.utilities.network;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class UserNetStatusTest {
+
+  @Test
+  public void equalityTest() {
+    UserNetStatus netStatus1 = new UserNetStatus();
+    UserNetStatus netStatus2 = new UserNetStatus();
+    FakeNetStatus fakeNetStatus = new FakeNetStatus();
+
+    assertEquals(netStatus1, netStatus1);
+    assertEquals(netStatus1, netStatus2);
+    assertNotEquals(null, netStatus1);
+    assertNotEquals(netStatus1, fakeNetStatus);
+
+    assertEquals(netStatus1.hashCode(), netStatus2.hashCode());
+  }
+
+  @Test
+  public void clearAllNetDelays() {
+    UserNetStatus netStatus = new UserNetStatus();
+    netStatus.addNetDelay(12);
+    netStatus.clearAllNetDelays();
+
+    assertEquals(Double.valueOf(0), Double.valueOf(netStatus.getAverageNetDelay()));
+  }
+
+  private class FakeNetStatus {
+
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/structure/FixedDequeTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/structure/FixedDequeTest.java
@@ -1,0 +1,108 @@
+package com.team04.musiccloud.utilities.structure;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class FixedDequeTest {
+
+  private FixedDeque<Integer> deque;
+
+  @Before
+  public void setUp() {
+    deque = new FixedDeque<>(3);
+  }
+
+  @Test
+  public void equalityTest() {
+    FixedDeque deque1 = new FixedDeque(3);
+    FixedDeque deque2 = new FixedDeque(3);
+    FakeDeque fakeDeque = new FakeDeque();
+
+    assertEquals(deque1, deque1);
+    assertEquals(deque1, deque2);
+    assertNotEquals(null, deque2);
+    assertNotEquals(deque1, fakeDeque);
+
+    assertEquals(deque1.hashCode(), deque2.hashCode());
+  }
+
+  @Test
+  public void getCapacity() {
+    assertEquals(3, deque.getCapacity());
+  }
+
+  @Test
+  public void isFull() {
+    assertFalse(deque.isFull());
+
+    deque.add(1);
+    deque.add(2);
+    deque.add(3);
+
+    assertTrue(deque.isFull());
+  }
+
+  @Test(expected = OverSizeLimitException.class)
+  public void addFirst() {
+    deque.add(1);
+    deque.add(2);
+    deque.addFirst(3);
+
+    assertEquals(3, deque.peekFirst().intValue());
+    assertTrue(deque.isFull());
+
+    deque.addFirst(4);
+  }
+
+  @Test(expected = OverSizeLimitException.class)
+  public void addLast() {
+    deque.add(1);
+    deque.add(2);
+    deque.addLast(3);
+
+    assertEquals(3, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+
+    deque.addLast(4);
+  }
+
+  @Test
+  public void offerFirst() {
+    deque.offer(1);
+    deque.offer(2);
+    deque.offerFirst(3);
+
+    assertEquals(3, deque.peekFirst().intValue());
+    assertTrue(deque.isFull());
+    assertFalse(deque.offerFirst(4));
+  }
+
+  @Test
+  public void offerLast() {
+    deque.offer(1);
+    deque.offer(2);
+    deque.offerLast(3);
+
+    assertEquals(3, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+    assertFalse(deque.offerLast(4));
+  }
+
+  @Test(expected = OverSizeLimitException.class)
+  public void push() {
+    deque.push(1);
+    deque.push(2);
+    deque.push(3);
+
+    assertEquals(3, deque.peek().intValue());
+    assertTrue(deque.isFull());
+
+    deque.push(4);
+  }
+
+  private class FakeDeque {
+
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/structure/OverSizeLimitExceptionTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/structure/OverSizeLimitExceptionTest.java
@@ -1,0 +1,53 @@
+package com.team04.musiccloud.utilities.structure;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class OverSizeLimitExceptionTest {
+
+  @Test(expected = OverSizeLimitException.class)
+  public void constructor() {
+    throw new OverSizeLimitException();
+  }
+
+  @Test
+  public void constructorWithMessage() {
+    try {
+      throw new OverSizeLimitException("Test");
+    } catch (Exception e) {
+      assertEquals("Test", e.getMessage());
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void constructorWithThrowable() throws Throwable {
+    try {
+
+      try {
+        throw new IllegalStateException();
+      } catch (Exception e) {
+        throw new OverSizeLimitException(e);
+      }
+
+    } catch (Exception e) {
+      throw e.getCause();
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void constructorWithMessageAndThrowable() throws Throwable {
+    try {
+
+      try {
+        throw new IllegalStateException();
+      } catch (Exception e) {
+        throw new OverSizeLimitException("Test", e);
+      }
+
+    } catch (Exception e) {
+      assertEquals("Test", e.getMessage());
+      throw e.getCause();
+    }
+  }
+}

--- a/src/test/java/com/team04/musiccloud/utilities/structure/UpdateDequeTest.java
+++ b/src/test/java/com/team04/musiccloud/utilities/structure/UpdateDequeTest.java
@@ -1,0 +1,121 @@
+package com.team04.musiccloud.utilities.structure;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class UpdateDequeTest {
+
+  private UpdateDeque<Integer> deque;
+
+  @Before
+  public void setUp() {
+    deque = new UpdateDeque<>(3);
+  }
+
+  @Test
+  public void addFirst() {
+    deque.add(1);
+    deque.add(2);
+    deque.addFirst(3);
+
+    assertEquals(3, deque.peekFirst().intValue());
+    assertTrue(deque.isFull());
+
+    deque.addFirst(4);
+
+    assertEquals(4, deque.peekFirst().intValue());
+    assertTrue(deque.isFull());
+  }
+
+  @Test
+  public void addLast() {
+    deque.add(1);
+    deque.add(2);
+    deque.addLast(3);
+
+    assertEquals(3, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+
+    deque.addLast(4);
+
+    assertEquals(4, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+  }
+
+  @Test
+  public void add() {
+    deque.add(1);
+    deque.add(2);
+    deque.add(3);
+
+    assertEquals(3, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+
+    deque.add(4);
+
+    assertEquals(4, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+  }
+
+  @Test
+  public void offerFirst() {
+    deque.offer(1);
+    deque.offer(2);
+    deque.offerFirst(3);
+
+    assertEquals(3, deque.peekFirst().intValue());
+    assertTrue(deque.isFull());
+
+    deque.offerFirst(4);
+
+    assertEquals(4, deque.peekFirst().intValue());
+    assertTrue(deque.isFull());
+  }
+
+  @Test
+  public void offerLast() {
+    deque.offer(1);
+    deque.offer(2);
+    deque.offerLast(3);
+
+    assertEquals(3, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+
+    deque.offerLast(4);
+
+    assertEquals(4, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+  }
+
+  @Test
+  public void offer() {
+    deque.offer(1);
+    deque.offer(2);
+    deque.offer(3);
+
+    assertEquals(3, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+
+    deque.offer(4);
+
+    assertEquals(4, deque.peekLast().intValue());
+    assertTrue(deque.isFull());
+  }
+
+  @Test
+  public void push() {
+    deque.push(1);
+    deque.push(2);
+    deque.push(3);
+
+    assertEquals(3, deque.peek().intValue());
+    assertTrue(deque.isFull());
+
+    deque.push(4);
+
+    assertEquals(4, deque.peek().intValue());
+    assertTrue(deque.isFull());
+  }
+}


### PR DESCRIPTION
Audio.java
- setAudioMeta won't make a duplicate to store its content in Audio

+ added test cases to cover the code coverage